### PR TITLE
Tweaking providers

### DIFF
--- a/.tours/terraforming-the-cloud-azure-2.tour
+++ b/.tours/terraforming-the-cloud-azure-2.tour
@@ -9,12 +9,17 @@
     },
     {
       "file": "README.md",
+      "description": "Certifica-te que estás no teu terminal fazendo o comando:\n- **ctrl+ç**\n\nAlternativamente, no canto superior esquerdo, podes também clicar em:\n\n- **View** e depois selecionar **Terminal**",
+      "line": 5
+    },
+    {
+      "file": "README.md",
       "description": "No terminal faz login em Azure utilizando o comando:\n- **az login --use-device-code**",
       "line": 2
     },
     {
       "file": "README.md",
-      "description": "Para definir a subscrição corre o seguinte comando:\n\n- **az account set --subscription < insert-value >**\n\nSe quiseres ver todas as tuas subscrições utiliza:\n\n- **az account list --output table**",
+      "description": "Para definir a subscrição:\n\n- Seleciona-a de entre as opções disponíveis no teu terminal recorrendo ao Nº da mesma.\n\nAlternativamente executa o comando:\n\n- **az account set --subscription < insert-value > (Subscription ID ou Subscription Name)**\n\nSe quiseres ver todas as tuas subscrições utiliza:\n\n- **az account list --output table**",
       "line": 3
     },
     {

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.8.1"
+  required_version = "1.9.5"
   backend "local" {
     path = "terraform.tfstate"
   }
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>3.106"
+      version = "4.14.0"
     }
   }
 }


### PR DESCRIPTION
This pull request includes updates to the `.tours/terraforming-the-cloud-azure-2.tour` and `main.tf` files to enhance the workshop instructions and update the Terraform and AzureRM provider versions.

Enhancements to workshop instructions:

* [`.tours/terraforming-the-cloud-azure-2.tour`](diffhunk://#diff-3b90fb189f1d81cc82568f32412d30c774785a4541732bd4fd07f631925e6447R10-R22): Added a new instruction to open the terminal using the command `ctrl+ç` or via the `View` menu. Updated the instruction for setting the subscription to include an alternative method using the subscription number.

Updates to Terraform and AzureRM provider versions:

* [`main.tf`](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL2-R10): Updated the required Terraform version to `1.9.5` and the AzureRM provider version to `4.14.0`.