### PR TITLE
Tweaking codetour step to include tenant

### DIFF
--- a/.tours/terraforming-the-cloud-azure-2.tour
+++ b/.tours/terraforming-the-cloud-azure-2.tour
@@ -14,7 +14,7 @@
     },
     {
       "file": "README.md",
-      "description": "No terminal faz login em Azure utilizando o comando:\n>> az login --use-device-code",
+      "description": "No terminal faz login em Azure utilizando o comando:\n>> az login --use-device-code --tenant nosportugal.onmicrosoft.com",
       "line": 2
     },
     {


### PR DESCRIPTION
This pull request includes an update to the Azure login command in the `.tours/terraforming-the-cloud-azure-2.tour` file to specify the tenant.

* [`.tours/terraforming-the-cloud-azure-2.tour`](diffhunk://#diff-3b90fb189f1d81cc82568f32412d30c774785a4541732bd4fd07f631925e6447L17-R17): Updated the Azure login command to include the tenant parameter `--tenant nosportugal.onmicrosoft.com`.