### PR TITLE
Tweaking codetour step to list container instances

### DIFF
--- a/.tours/terraforming-the-cloud-azure-2.tour
+++ b/.tours/terraforming-the-cloud-azure-2.tour
@@ -358,7 +358,7 @@
     },
     {
       "file": "main.tf",
-      "description": "Podemos verificar que as container apps foram corretamente criadas:\n\n>> for app_name in $(terraform output -json count_container_app_name | jq -r '.[]'); do az containerapp show --name $app_name --resource-group $(terraform output -raw resource_group_name) --output table\n",
+      "description": "Podemos verificar que as container apps foram corretamente criadas:\n\n>> for app_name in $(terraform output -json count_container_app_name | jq -r '.[]'); do az containerapp show --name $app_name --resource-group $(terraform output -raw resource_group_name) --output table; done",
       "line": 121
     },
     {


### PR DESCRIPTION
This pull request includes a minor fix to the `.tours/terraforming-the-cloud-azure-2.tour` file. The change corrects the syntax of a command by adding a missing semicolon and the `done` keyword at the end of a `for` loop.

* [`.tours/terraforming-the-cloud-azure-2.tour`](diffhunk://#diff-3b90fb189f1d81cc82568f32412d30c774785a4541732bd4fd07f631925e6447L361-R361): Corrected the syntax of a `for` loop command by adding a missing semicolon and the `done` keyword.